### PR TITLE
Update _package.json

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -13,7 +13,7 @@
     "grunt-contrib-copy": "^0.8.0",
     "grunt-contrib-cssmin": "^0.12.2",
     "grunt-contrib-htmlmin": "^0.4.0",
-    "grunt-contrib-imagemin": "^0.9.3",
+    "grunt-contrib-imagemin": "^1.0.0",
 <% if (testFramework === 'jasmine') { -%>
     "grunt-contrib-jasmine": "^0.8.2",
 <% } -%>


### PR DESCRIPTION
During my "grunt build" 
I went through an Imagemim error like this :
`Fatal error: Cannot read property 'contents' of undefined`

By digging a bit, I found that the imagemim 0.9.3 is outdated so i updated the package.json.

Here :
https://github.com/gruntjs/grunt-contrib-imagemin/issues/208